### PR TITLE
fix: Re-anable textureMode to fix blank map issue

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 class MapboxMapBuilder implements MapboxMapOptionsSink {
   public final String TAG = getClass().getSimpleName();
   private final MapboxMapOptions options = new MapboxMapOptions()
+    .textureMode(true)
     .attributionEnabled(true);
   private boolean trackCameraPosition = false;
   private boolean myLocationEnabled = false;


### PR DESCRIPTION
This line of code was removed from v.0.14. This seems to fix the blank map issue. It is important to understand what textureMode does. There was no mention made in the change logs of why this was removed in the first place.